### PR TITLE
Added generic keyDown event

### DIFF
--- a/nicEdit.js
+++ b/nicEdit.js
@@ -523,6 +523,8 @@ var nicEditorInstance = bkClass.extend({
 	},
 	
 	keyDown : function(e,t) {
+		this.ne.fireEvent('keyDown',this,e);
+		
 		if(e.ctrlKey) {
 			this.ne.fireEvent('key',this,e);
 		}


### PR DESCRIPTION
We needed a keyDown event to save changes after the user's done typing.  Rather than send "key" only when Ctrl is held down, we just fire keyDown whenever a key is pressed.
