### PR TITLE
Allow turning off initializing content with a line break

### DIFF
--- a/nicEdit.js
+++ b/nicEdit.js
@@ -799,7 +799,9 @@ var nicEditorButton = bkClass.extend({
 		this.isDisabled = false;
 		this.contain.setStyle({'opacity' : 1}).addClass('buttonEnabled');
 		this.updateState();
-		this.checkNodes(t);
+		if (t !== document) {
+			this.checkNodes(t);
+		}
 	},
 
 	disable : function(ins,t) {


### PR DESCRIPTION
We needed the content to actually be empty, so we added an option.
